### PR TITLE
Update operator.pp to match the right templatename

### DIFF
--- a/manifests/operator.pp
+++ b/manifests/operator.pp
@@ -9,7 +9,7 @@ define ngircd::operator(
 
   concat::fragment { "oper_${name}":
     target  => $ngircd::params::config_file,
-    content => template("${module_name}/oper.erb"),
+    content => template("${module_name}/operator.erb"),
     order   => '06',
   }
 


### PR DESCRIPTION
Change oper.erb to operator.erb as that's the right name in the templates folder
